### PR TITLE
Add support for GCR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gitops-tools/image-updater
 go 1.14
 
 require (
+	cloud.google.com/go/pubsub v1.0.1
 	github.com/gitops-tools/pkg v0.0.0-20200823054310-42f81b2b396d
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,12 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
+cloud.google.com/go v0.46.3 h1:AVXDdKsrtX33oR9fbCMu/+c1o8Ofjq6Ku/MInaLVg5Y=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
+cloud.google.com/go/pubsub v1.0.1 h1:W9tAK3E57P75u0XLLR82LZyw8VpAnhmyTOxW9qzmyj8=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -192,6 +194,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -227,6 +230,7 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -422,6 +426,7 @@ go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
+go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -504,6 +509,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -582,6 +588,7 @@ google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEt
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
+google.golang.org/api v0.13.0 h1:Q3Ui3V3/CVinFWFiW39Iw0kMuVrRzYX0wN6OPFp0lTA=
 google.golang.org/api v0.13.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -604,6 +611,7 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/pkg/cmd/pubsub.go
+++ b/pkg/cmd/pubsub.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/gitops-tools/image-updater/pkg/applier"
+	"github.com/gitops-tools/image-updater/pkg/config"
+	"github.com/gitops-tools/image-updater/pkg/hooks/gcr"
+	"github.com/gitops-tools/image-updater/pkg/pubsubhandler"
+	"github.com/gitops-tools/pkg/client"
+	"github.com/go-logr/zapr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+const (
+	projectIDFlag        = "project-id"
+	subscriptionNameFlag = "subscription-name"
+)
+
+type message struct {
+	data []byte
+}
+
+func (m *message) Ack()         {}
+func (m *message) Data() []byte { return m.data }
+
+func makePubsubCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pubsub",
+		Short: "update repositories in response to gcr pubsub events",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			zapl, _ := zap.NewProduction()
+			defer func() {
+				_ = zapl.Sync() // flushes buffer, if any
+			}()
+			logger := zapr.NewLogger(zapl)
+			scmClient, err := createClientFromViper()
+			if err != nil {
+				return fmt.Errorf("failed to create a git driver: %s", err)
+			}
+			f, err := os.Open(viper.GetString("config"))
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			repos, err := config.Parse(f)
+			if err != nil {
+				return err
+			}
+			applier := applier.New(logger, client.New(scmClient), repos)
+
+			sub, err := createSubscriptionFromViper()
+			if err != nil {
+				return err
+			}
+
+			handler := pubsubhandler.New(logger, applier, gcr.Parse)
+
+			return sub.Receive(context.Background(), func(ctx context.Context, msg *pubsub.Message) {
+				handler.Handle(ctx, &message{
+					data: msg.Data,
+				})
+			})
+		},
+	}
+
+	cmd.Flags().String(
+		"config",
+		"/etc/image-updater/config.yaml",
+		"repository configuration",
+	)
+	logIfError(viper.BindPFlag("config", cmd.Flags().Lookup("config")))
+
+	cmd.Flags().String(
+		projectIDFlag,
+		"",
+		"GCP project ID",
+	)
+	logIfError(viper.BindPFlag(projectIDFlag, cmd.Flags().Lookup(projectIDFlag)))
+	logIfError(cmd.MarkFlagRequired(projectIDFlag))
+
+	cmd.Flags().String(
+		subscriptionNameFlag,
+		"",
+		"GCP subscription name",
+	)
+	logIfError(viper.BindPFlag(subscriptionNameFlag, cmd.Flags().Lookup(subscriptionNameFlag)))
+	logIfError(cmd.MarkFlagRequired(subscriptionNameFlag))
+
+	return cmd
+}
+
+func createSubscriptionFromViper() (*pubsub.Subscription, error) {
+	ctx := context.Background()
+	projectID := viper.GetString(projectIDFlag)
+	subscriptionName := viper.GetString(subscriptionNameFlag)
+
+	client, err := pubsub.NewClient(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	sub := client.Subscription(subscriptionName)
+	return sub, nil
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -60,6 +60,7 @@ func makeRootCmd() *cobra.Command {
 
 	cmd.AddCommand(makeHTTPCmd())
 	cmd.AddCommand(makeUpdateCmd())
+	cmd.AddCommand(makePubsubCmd())
 	return cmd
 }
 

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -35,6 +35,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) parse(r *http.Request) (hooks.PushEvent, error) {
 	h.log.Info("processing hook request")
+	// TODO: LimitReader
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		h.log.Error(err, "failed to read request body")

--- a/pkg/hooks/docker/hook.go
+++ b/pkg/hooks/docker/hook.go
@@ -3,21 +3,14 @@ package docker
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/gitops-tools/image-updater/pkg/hooks"
 )
 
-// Parse takes an http.Request and parses it into a Docker webhook event.
-func Parse(req *http.Request) (hooks.PushEvent, error) {
-	// TODO: LimitReader
-	data, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
+// Parse parses a payload into a Docker webhook event.
+func Parse(payload []byte) (hooks.PushEvent, error) {
 	h := &Webhook{}
-	err = json.Unmarshal(data, h)
+	err := json.Unmarshal(payload, h)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hooks/docker/hook_test.go
+++ b/pkg/hooks/docker/hook_test.go
@@ -1,11 +1,7 @@
 package docker
 
 import (
-	"bytes"
-	"errors"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -55,28 +51,6 @@ func TestParse(t *testing.T) {
 	}
 }
 
-func TestParseWithNoBody(t *testing.T) {
-	bodyErr := errors.New("just a test error")
-
-	req := httptest.NewRequest("POST", "/", failingReader{err: bodyErr})
-
-	_, err := Parse(req)
-	if err != bodyErr {
-		t.Fatal("expected an error")
-	}
-
-}
-
-func TestParseWithUnparseableBody(t *testing.T) {
-	req := httptest.NewRequest("POST", "/", nil)
-
-	_, err := Parse(req)
-
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-}
-
 func TestPushedImageURL(t *testing.T) {
 	hook := &Webhook{
 		PushData: &PushData{
@@ -109,24 +83,11 @@ func TestRepository(t *testing.T) {
 	}
 }
 
-func makeHookRequest(t *testing.T, fixture string) *http.Request {
+func makeHookRequest(t *testing.T, fixture string) []byte {
 	t.Helper()
 	b, err := ioutil.ReadFile(fixture)
 	if err != nil {
 		t.Fatalf("failed to read %s: %s", fixture, err)
 	}
-	req := httptest.NewRequest("POST", "/", bytes.NewReader(b))
-	req.Header.Add("Content-Type", "application/json")
-	return req
-}
-
-type failingReader struct {
-	err error
-}
-
-func (f failingReader) Read(p []byte) (n int, err error) {
-	return 0, f.err
-}
-func (f failingReader) Close() error {
-	return f.err
+	return b
 }

--- a/pkg/hooks/docker/hook_test.go
+++ b/pkg/hooks/docker/hook_test.go
@@ -13,7 +13,7 @@ var _ hooks.PushEvent = (*Webhook)(nil)
 var _ hooks.PushEventParser = Parse
 
 func TestParse(t *testing.T) {
-	req := makeHookRequest(t, "testdata/push_event.json")
+	req := readFixture(t, "testdata/push_event.json")
 
 	hook, err := Parse(req)
 	if err != nil {
@@ -83,7 +83,7 @@ func TestRepository(t *testing.T) {
 	}
 }
 
-func makeHookRequest(t *testing.T, fixture string) []byte {
+func readFixture(t *testing.T, fixture string) []byte {
 	t.Helper()
 	b, err := ioutil.ReadFile(fixture)
 	if err != nil {

--- a/pkg/hooks/gcr/hook.go
+++ b/pkg/hooks/gcr/hook.go
@@ -3,8 +3,6 @@ package gcr
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"strings"
 
 	"github.com/gitops-tools/image-updater/pkg/hooks"
@@ -32,16 +30,11 @@ func (m PushMessage) EventTag() string {
 	return strings.Split(m.Tag, ":")[1]
 }
 
-// Parse takes an http request and returns a PushEvent
-func Parse(req *http.Request) (hooks.PushEvent, error) {
-	data, err := ioutil.ReadAll(req.Body)
-
-	if err != nil {
-		return nil, err
-	}
+// Parse parses a payload into a GCR PushEvent
+func Parse(payload []byte) (hooks.PushEvent, error) {
 	msg := &PushMessage{}
 
-	err = json.Unmarshal(data, &msg)
+	err := json.Unmarshal(payload, &msg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hooks/gcr/hook.go
+++ b/pkg/hooks/gcr/hook.go
@@ -2,7 +2,7 @@ package gcr
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/gitops-tools/image-updater/pkg/hooks"
@@ -40,7 +40,7 @@ func Parse(payload []byte) (hooks.PushEvent, error) {
 	}
 
 	if msg.Tag == "" {
-		return nil, fmt.Errorf("Tag is empty")
+		return nil, errors.New("tag is empty")
 	}
 
 	return msg, nil

--- a/pkg/hooks/gcr/hook.go
+++ b/pkg/hooks/gcr/hook.go
@@ -1,0 +1,54 @@
+package gcr
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/gitops-tools/image-updater/pkg/hooks"
+)
+
+// PushMessage is a struct for the GCR push event
+type PushMessage struct {
+	Action string `json:"action,omitempty"`
+	Digest string `json:"digest,omitempty"`
+	Tag    string `json:"tag,omitempty"`
+}
+
+// PushedImageURL is an implementation of the hooks.PushEvent interface.
+func (m PushMessage) PushedImageURL() string {
+	return m.Tag
+}
+
+// EventRepository is an implementation of the hooks.PushEvent interface.
+func (m PushMessage) EventRepository() string {
+	return strings.Split(m.Tag, ":")[0]
+}
+
+// EventTag is an implementation of the hooks.PushEvent interface.
+func (m PushMessage) EventTag() string {
+	return strings.Split(m.Tag, ":")[1]
+}
+
+// Parse takes an http request and returns a PushEvent
+func Parse(req *http.Request) (hooks.PushEvent, error) {
+	data, err := ioutil.ReadAll(req.Body)
+
+	if err != nil {
+		return nil, err
+	}
+	msg := &PushMessage{}
+
+	err = json.Unmarshal(data, &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	if msg.Tag == "" {
+		return nil, fmt.Errorf("Tag is empty")
+	}
+
+	return msg, nil
+}

--- a/pkg/hooks/gcr/hook_test.go
+++ b/pkg/hooks/gcr/hook_test.go
@@ -1,0 +1,105 @@
+package gcr
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/gitops-tools/image-updater/pkg/hooks"
+)
+
+var _ hooks.PushEvent = (*PushMessage)(nil)
+var _ hooks.PushEventParser = Parse
+
+func TestParse(t *testing.T) {
+	req := makeHookRequest(t, "testdata/push_event.json")
+
+	hook, err := Parse(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &PushMessage{
+		Action: "INSERT",
+		Digest: "gcr.io/mynamespace/repository@sha256:6ec128e26cd5",
+		Tag:    "gcr.io/mynamespace/repository:latest",
+	}
+	if diff := cmp.Diff(want, hook); diff != "" {
+		t.Fatalf("hook doesn't match:\n%s", diff)
+	}
+}
+
+func TestParseWithNoBody(t *testing.T) {
+	bodyErr := errors.New("just a test error")
+
+	req := httptest.NewRequest("POST", "/", failingReader{err: bodyErr})
+
+	_, err := Parse(req)
+	if err != bodyErr {
+		t.Fatal("expected an error")
+	}
+
+}
+
+func TestParseWithUnparseableBody(t *testing.T) {
+	req := httptest.NewRequest("POST", "/", nil)
+
+	_, err := Parse(req)
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+func TestPushedImageURL(t *testing.T) {
+	hook := &PushMessage{
+		Action: "INSERT",
+		Digest: "gcr.io/mynamespace/repository@sha256:6ec128e26cd5",
+		Tag:    "gcr.io/mynamespace/repository:latest",
+	}
+	want := "gcr.io/mynamespace/repository:latest"
+
+	if u := hook.PushedImageURL(); u != want {
+		t.Fatalf("got %s, want %s", u, want)
+	}
+}
+
+func TestRepository(t *testing.T) {
+	hook := &PushMessage{
+		Action: "INSERT",
+		Digest: "gcr.io/mynamespace/repository@sha256:6ec128e26cd5",
+		Tag:    "gcr.io/mynamespace/repository:latest",
+	}
+	want := "gcr.io/mynamespace/repository"
+
+	if u := hook.EventRepository(); u != want {
+		t.Fatalf("got %s, want %s", u, want)
+	}
+}
+
+func makeHookRequest(t *testing.T, fixture string) *http.Request {
+	t.Helper()
+	b, err := ioutil.ReadFile(fixture)
+	if err != nil {
+		t.Fatalf("failed to read %s: %s", fixture, err)
+	}
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(b))
+	req.Header.Add("Content-Type", "application/json")
+	return req
+}
+
+type failingReader struct {
+	err error
+}
+
+func (f failingReader) Read(p []byte) (n int, err error) {
+	return 0, f.err
+}
+func (f failingReader) Close() error {
+	return f.err
+}

--- a/pkg/hooks/gcr/hook_test.go
+++ b/pkg/hooks/gcr/hook_test.go
@@ -1,11 +1,7 @@
 package gcr
 
 import (
-	"bytes"
-	"errors"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,28 +27,6 @@ func TestParse(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, hook); diff != "" {
 		t.Fatalf("hook doesn't match:\n%s", diff)
-	}
-}
-
-func TestParseWithNoBody(t *testing.T) {
-	bodyErr := errors.New("just a test error")
-
-	req := httptest.NewRequest("POST", "/", failingReader{err: bodyErr})
-
-	_, err := Parse(req)
-	if err != bodyErr {
-		t.Fatal("expected an error")
-	}
-
-}
-
-func TestParseWithUnparseableBody(t *testing.T) {
-	req := httptest.NewRequest("POST", "/", nil)
-
-	_, err := Parse(req)
-
-	if err == nil {
-		t.Fatal("expected an error")
 	}
 }
 
@@ -82,15 +56,13 @@ func TestRepository(t *testing.T) {
 	}
 }
 
-func makeHookRequest(t *testing.T, fixture string) *http.Request {
+func makeHookRequest(t *testing.T, fixture string) []byte {
 	t.Helper()
 	b, err := ioutil.ReadFile(fixture)
 	if err != nil {
 		t.Fatalf("failed to read %s: %s", fixture, err)
 	}
-	req := httptest.NewRequest("POST", "/", bytes.NewReader(b))
-	req.Header.Add("Content-Type", "application/json")
-	return req
+	return b
 }
 
 type failingReader struct {

--- a/pkg/hooks/gcr/hook_test.go
+++ b/pkg/hooks/gcr/hook_test.go
@@ -13,9 +13,9 @@ var _ hooks.PushEvent = (*PushMessage)(nil)
 var _ hooks.PushEventParser = Parse
 
 func TestParse(t *testing.T) {
-	req := makeHookRequest(t, "testdata/push_event.json")
+	event := readFixture(t, "testdata/push_event.json")
 
-	hook, err := Parse(req)
+	hook, err := Parse(event)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,22 +56,11 @@ func TestRepository(t *testing.T) {
 	}
 }
 
-func makeHookRequest(t *testing.T, fixture string) []byte {
+func readFixture(t *testing.T, fixture string) []byte {
 	t.Helper()
 	b, err := ioutil.ReadFile(fixture)
 	if err != nil {
 		t.Fatalf("failed to read %s: %s", fixture, err)
 	}
 	return b
-}
-
-type failingReader struct {
-	err error
-}
-
-func (f failingReader) Read(p []byte) (n int, err error) {
-	return 0, f.err
-}
-func (f failingReader) Close() error {
-	return f.err
 }

--- a/pkg/hooks/gcr/testdata/push_event.json
+++ b/pkg/hooks/gcr/testdata/push_event.json
@@ -1,0 +1,5 @@
+{
+  "action": "INSERT",
+  "digest": "gcr.io/mynamespace/repository@sha256:6ec128e26cd5",
+  "tag": "gcr.io/mynamespace/repository:latest"
+}

--- a/pkg/hooks/interface.go
+++ b/pkg/hooks/interface.go
@@ -1,7 +1,5 @@
 package hooks
 
-import "net/http"
-
 // PushEvent values return the image that is to be inserted into the file.
 type PushEvent interface {
 	PushedImageURL() string
@@ -10,4 +8,4 @@ type PushEvent interface {
 }
 
 // PushEventParser parses the specifics of a hook request into a body.
-type PushEventParser func(req *http.Request) (PushEvent, error)
+type PushEventParser func(payload []byte) (PushEvent, error)

--- a/pkg/hooks/quay/hook.go
+++ b/pkg/hooks/quay/hook.go
@@ -3,22 +3,14 @@ package quay
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/gitops-tools/image-updater/pkg/hooks"
 )
 
-// Parse takes an http.Request and parses it into a Quay.io Push hook if
-// possible.
-func Parse(req *http.Request) (hooks.PushEvent, error) {
-	// TODO: LimitReader
-	data, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
+// Parse parses a payload it into a Quay.io Push hook if possible.
+func Parse(payload []byte) (hooks.PushEvent, error) {
 	h := &RepositoryPushHook{}
-	err = json.Unmarshal(data, h)
+	err := json.Unmarshal(payload, h)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hooks/quay/hook_test.go
+++ b/pkg/hooks/quay/hook_test.go
@@ -12,7 +12,7 @@ var _ hooks.PushEvent = (*RepositoryPushHook)(nil)
 var _ hooks.PushEventParser = Parse
 
 func TestParse(t *testing.T) {
-	req := makeHookRequest(t, "testdata/push_hook.json")
+	req := readFixture(t, "testdata/push_hook.json")
 
 	hook, err := Parse(req)
 	if err != nil {
@@ -73,22 +73,11 @@ func TestEventTag(t *testing.T) {
 	}
 }
 
-func makeHookRequest(t *testing.T, fixture string) []byte {
+func readFixture(t *testing.T, fixture string) []byte {
 	t.Helper()
 	b, err := ioutil.ReadFile(fixture)
 	if err != nil {
 		t.Fatalf("failed to read %s: %s", fixture, err)
 	}
 	return b
-}
-
-type failingReader struct {
-	err error
-}
-
-func (f failingReader) Read(p []byte) (n int, err error) {
-	return 0, f.err
-}
-func (f failingReader) Close() error {
-	return f.err
 }

--- a/pkg/hooks/quay/hook_test.go
+++ b/pkg/hooks/quay/hook_test.go
@@ -1,11 +1,7 @@
 package quay
 
 import (
-	"bytes"
-	"errors"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/gitops-tools/image-updater/pkg/hooks"
@@ -33,28 +29,6 @@ func TestParse(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, hook); diff != "" {
 		t.Fatalf("hook doesn't match:\n%s", diff)
-	}
-}
-
-func TestParseWithNoBody(t *testing.T) {
-	bodyErr := errors.New("just a test error")
-
-	req := httptest.NewRequest("POST", "/", failingReader{err: bodyErr})
-
-	_, err := Parse(req)
-	if err != bodyErr {
-		t.Fatal("expected an error")
-	}
-
-}
-
-func TestParseWithUnparseableBody(t *testing.T) {
-	req := httptest.NewRequest("POST", "/", nil)
-
-	_, err := Parse(req)
-
-	if err == nil {
-		t.Fatal("expected an error")
 	}
 }
 
@@ -99,15 +73,13 @@ func TestEventTag(t *testing.T) {
 	}
 }
 
-func makeHookRequest(t *testing.T, fixture string) *http.Request {
+func makeHookRequest(t *testing.T, fixture string) []byte {
 	t.Helper()
 	b, err := ioutil.ReadFile(fixture)
 	if err != nil {
 		t.Fatalf("failed to read %s: %s", fixture, err)
 	}
-	req := httptest.NewRequest("POST", "/", bytes.NewReader(b))
-	req.Header.Add("Content-Type", "application/json")
-	return req
+	return b
 }
 
 type failingReader struct {

--- a/pkg/pubsubhandler/handler.go
+++ b/pkg/pubsubhandler/handler.go
@@ -1,0 +1,58 @@
+package pubsubhandler
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gitops-tools/image-updater/pkg/applier"
+	"github.com/gitops-tools/image-updater/pkg/hooks"
+	"github.com/go-logr/logr"
+)
+
+// Handler parses and processes pubsub messages.
+type Handler struct {
+	applier *applier.Applier
+	log     logr.Logger
+	parser  hooks.PushEventParser
+}
+
+// New creates and returns a new Handler.
+func New(logger logr.Logger, u *applier.Applier, p hooks.PushEventParser) *Handler {
+	return &Handler{log: logger, applier: u, parser: p}
+}
+
+// Handle acks, parses and processes pubsub messages
+func (h *Handler) Handle(ctx context.Context, m message) {
+	h.log.Info("processing hook request")
+
+	req, err := h.convertToHTTP(ctx, m)
+	if err != nil {
+		h.log.Error(err, "failed to parse message")
+		return
+	}
+	hook, err := h.parser(req)
+	if err != nil {
+		h.log.Error(err, "failed to parse request")
+		return
+	}
+
+	err = h.applier.UpdateFromHook(ctx, hook)
+
+	if err != nil {
+		h.log.Error(err, "hook update failed")
+		return
+	}
+
+	m.Ack()
+}
+
+func (h *Handler) convertToHTTP(ctx context.Context, m message) (*http.Request, error) {
+	r := strings.NewReader(string(m.Data()))
+
+	req, err := http.NewRequest("POST", "application/json", r)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}

--- a/pkg/pubsubhandler/handler.go
+++ b/pkg/pubsubhandler/handler.go
@@ -2,8 +2,6 @@ package pubsubhandler
 
 import (
 	"context"
-	"net/http"
-	"strings"
 
 	"github.com/gitops-tools/image-updater/pkg/applier"
 	"github.com/gitops-tools/image-updater/pkg/hooks"
@@ -26,12 +24,7 @@ func New(logger logr.Logger, u *applier.Applier, p hooks.PushEventParser) *Handl
 func (h *Handler) Handle(ctx context.Context, m message) {
 	h.log.Info("processing hook request")
 
-	req, err := h.convertToHTTP(ctx, m)
-	if err != nil {
-		h.log.Error(err, "failed to parse message")
-		return
-	}
-	hook, err := h.parser(req)
+	hook, err := h.parser(m.Data())
 	if err != nil {
 		h.log.Error(err, "failed to parse request")
 		return
@@ -45,14 +38,4 @@ func (h *Handler) Handle(ctx context.Context, m message) {
 	}
 
 	m.Ack()
-}
-
-func (h *Handler) convertToHTTP(ctx context.Context, m message) (*http.Request, error) {
-	r := strings.NewReader(string(m.Data()))
-
-	req, err := http.NewRequest("POST", "application/json", r)
-	if err != nil {
-		return nil, err
-	}
-	return req, nil
 }

--- a/pkg/pubsubhandler/handler_test.go
+++ b/pkg/pubsubhandler/handler_test.go
@@ -34,7 +34,7 @@ func TestHandler(t *testing.T) {
 
 	h := New(logger, applier, gcr.Parse)
 
-	msg := makeHookMessage(t, "testdata/push_event.json")
+	msg := readFixture(t, "testdata/push_event.json")
 
 	h.Handle(context.TODO(), msg)
 
@@ -46,7 +46,7 @@ func TestHandler(t *testing.T) {
 	})
 }
 
-func makeHookMessage(t *testing.T, fixture string) *stubMessage {
+func readFixture(t *testing.T, fixture string) *stubMessage {
 	t.Helper()
 	b, err := ioutil.ReadFile(fixture)
 	if err != nil {

--- a/pkg/pubsubhandler/handler_test.go
+++ b/pkg/pubsubhandler/handler_test.go
@@ -1,0 +1,89 @@
+package pubsubhandler
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/gitops-tools/pkg/client/mock"
+	"github.com/gitops-tools/pkg/updater"
+	"github.com/go-logr/zapr"
+	"github.com/jenkins-x/go-scm/scm"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/gitops-tools/image-updater/pkg/applier"
+	"github.com/gitops-tools/image-updater/pkg/config"
+	"github.com/gitops-tools/image-updater/pkg/hooks/gcr"
+)
+
+const (
+	testGcrRepo    = "gcr.io/mynamespace/repository"
+	testGitHubRepo = "testorg/testrepo"
+	testFilePath   = "environments/test/services/service-a/test.yaml"
+)
+
+func TestHandler(t *testing.T) {
+	testSHA := "980a0d5f19a64b4b30a87d4206aade58726b60e3"
+	logger := zapr.NewLogger(zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel)))
+	m := mock.New(t)
+	m.AddBranchHead(testGitHubRepo, "master", testSHA)
+	m.AddFileContents(testGitHubRepo, testFilePath, "master", []byte("test:\n  image: old-image\n"))
+	applier := applier.New(logger, m, createConfigs(), updater.NameGenerator(stubNameGenerator{"a"}))
+
+	h := New(logger, applier, gcr.Parse)
+
+	msg := makeHookMessage(t, "testdata/push_event.json")
+
+	h.Handle(context.TODO(), msg)
+
+	m.AssertPullRequestCreated(testGitHubRepo, &scm.PullRequestInput{
+		Body:  fmt.Sprintf("Automated update from %q", testGcrRepo),
+		Head:  "test-branch-a",
+		Base:  "master",
+		Title: "Automated image update",
+	})
+}
+
+func makeHookMessage(t *testing.T, fixture string) *stubMessage {
+	t.Helper()
+	b, err := ioutil.ReadFile(fixture)
+	if err != nil {
+		t.Fatalf("failed to read %s: %s", fixture, err)
+	}
+	msg := &stubMessage{
+		data: b,
+	}
+	return msg
+}
+
+func createConfigs() *config.RepoConfiguration {
+	return &config.RepoConfiguration{
+		Repositories: []*config.Repository{
+			{
+				Name:               testGcrRepo,
+				SourceRepo:         testGitHubRepo,
+				SourceBranch:       "master",
+				FilePath:           testFilePath,
+				UpdateKey:          "test.image",
+				BranchGenerateName: "test-branch-",
+			},
+		},
+	}
+}
+
+type stubMessage struct {
+	data []byte
+}
+
+func (m *stubMessage) Ack()         {}
+func (m *stubMessage) Data() []byte { return m.data }
+
+type stubNameGenerator struct {
+	name string
+}
+
+func (s stubNameGenerator) PrefixedName(p string) string {
+	return p + s.name
+}

--- a/pkg/pubsubhandler/interface.go
+++ b/pkg/pubsubhandler/interface.go
@@ -1,0 +1,6 @@
+package pubsubhandler
+
+type message interface {
+	Ack()
+	Data() []byte
+}

--- a/pkg/pubsubhandler/testdata/push_event.json
+++ b/pkg/pubsubhandler/testdata/push_event.json
@@ -1,0 +1,5 @@
+{
+  "action": "INSERT",
+  "digest": "gcr.io/mynamespace/repository@sha256:6ec128e26cd5",
+  "tag": "gcr.io/mynamespace/repository:latest"
+}


### PR DESCRIPTION
This PR adds a new command `pubsub` to receive [Google Cloud Registry](https://cloud.google.com/container-registry/docs/configuring-notifications) events. 

To support both HTTP requests and Pubsub events, `PushEventParser` have been modified to accept `[]byte` instead of  `http.Request`.

The HTTP request Body now being parsed in the `handler`, tests related to the parsing of an invalid request have been moved to the `handler` package.

___
This project is exactly what I have been looking for to manage image updates, thanks! 
Also, I'm pretty new to go, so feel free to suggest changes / refactorings. 